### PR TITLE
Add hierarchical division/area/zone support for VDFs

### DIFF
--- a/vdf_monitor/admin.py
+++ b/vdf_monitor/admin.py
@@ -36,9 +36,6 @@ class VDFAdmin(admin.ModelAdmin):
         "zona__nombre",
         "zona__area__nombre",
         "zona__area__division__nombre",
-        "division",
-        "area",
-        "zone",
     ]
 
     ordering = (

--- a/vdf_monitor/admin.py
+++ b/vdf_monitor/admin.py
@@ -4,20 +4,97 @@
 # ——————————————————————————————————————————————————————————————
 
 from django.contrib import admin                 # Importa el admin de Django
-from .models import VDF, Lectura                 # Importa TUS modelos (ojo: Lectura, no LecturaVDF)
+from .models import Division, Area, Zona, VDF, Lectura  # Importa tus modelos
+
 
 @admin.register(VDF)
 class VDFAdmin(admin.ModelAdmin):
-    # list_display: columnas que se ven en la tabla del admin
-    list_display  = ('nombre', 'division', 'area', 'zone', 'ip', 'tag', 'tipo')
-    # list_filter: filtros laterales (debe ser lista/tupla)
-    list_filter   = ['tipo', 'division', 'area', 'zone']
-    # search_fields: búsqueda por estos campos (lista/tupla)
-    search_fields = ['nombre', 'ip', 'tag', 'division', 'area', 'zone']
-    # ordering: orden por defecto
-    ordering      = ('division', 'area', 'zone', 'tipo', 'tag')
-    # list_per_page: paginación en el admin
+    """Formulario del admin para VDF.
+
+    Se usa la relación normalizada ``zona`` para elegir ubicación y se excluyen
+    los antiguos campos de texto ``division``, ``area`` y ``zone`` para evitar
+    confusiones al crear/editar.
+    """
+
+    # Mostrar la jerarquía resuelta en la lista
+    list_display = (
+        "nombre",
+        "division_name",
+        "area_name",
+        "zona_name",
+        "ip",
+        "tag",
+        "tipo",
+    )
+
+    # Filtros y búsquedas sobre la jerarquía normalizada
+    list_filter = ["tipo", "zona__area__division", "zona__area", "zona"]
+    search_fields = [
+        "nombre",
+        "ip",
+        "tag",
+        "zona__nombre",
+        "zona__area__nombre",
+        "zona__area__division__nombre",
+        "division",
+        "area",
+        "zone",
+    ]
+
+    ordering = (
+        "zona__area__division__nombre",
+        "zona__area__nombre",
+        "zona__nombre",
+        "tipo",
+        "tag",
+    )
+
+    # Formulario solo con la zona normalizada y demás datos del VDF
+    fields = ("nombre", "zona", "ip", "slot", "tag", "tipo", "descripcion")
+    autocomplete_fields = ("zona",)
+
     list_per_page = 50
+
+    # --------------------
+    # Helpers para mostrar la jerarquía
+    # --------------------
+    def division_name(self, obj):
+        return obj.zona.area.division.nombre if obj.zona_id else obj.division
+
+    division_name.short_description = "División"
+
+    def area_name(self, obj):
+        return obj.zona.area.nombre if obj.zona_id else obj.area
+
+    area_name.short_description = "Área"
+
+    def zona_name(self, obj):
+        return obj.zona.nombre if obj.zona_id else obj.zone
+
+    zona_name.short_description = "Zona"
+
+
+@admin.register(Division)
+class DivisionAdmin(admin.ModelAdmin):
+    list_display = ("nombre",)
+    search_fields = ("nombre",)
+    ordering = ("nombre",)
+
+
+@admin.register(Area)
+class AreaAdmin(admin.ModelAdmin):
+    list_display = ("division", "nombre")
+    list_filter = ("division",)
+    search_fields = ("nombre", "division__nombre")
+    ordering = ("division__nombre", "nombre")
+
+
+@admin.register(Zona)
+class ZonaAdmin(admin.ModelAdmin):
+    list_display = ("area", "nombre")
+    list_filter = ("area__division", "area")
+    search_fields = ("nombre", "area__nombre", "area__division__nombre")
+    ordering = ("area__division__nombre", "area__nombre", "nombre")
 
 @admin.register(Lectura)
 class LecturaAdmin(admin.ModelAdmin):

--- a/vdf_monitor/serializers.py
+++ b/vdf_monitor/serializers.py
@@ -1,7 +1,7 @@
 # Importa las utilidades de DRF para crear serializadores
 from rest_framework import serializers
 # Importa tus modelos VDF y Lectura
-from .models import VDF, Lectura
+from .models import Division, Area, Zona, VDF, Lectura
 
 class LecturaSerializer(serializers.ModelSerializer):
     """ Serializa una lectura individual (valor + fecha). """
@@ -9,38 +9,84 @@ class LecturaSerializer(serializers.ModelSerializer):
         model = Lectura                             # Modelo a serializar
         fields = ('valor', 'timestamp')             # Campos expuestos en la API
 
+class DivisionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Division
+        fields = ("id", "nombre")
+
+
+class AreaSerializer(serializers.ModelSerializer):
+    division_nombre = serializers.CharField(source="division.nombre", read_only=True)
+
+    class Meta:
+        model = Area
+        fields = ("id", "division", "division_nombre", "nombre")
+
+
+class ZonaSerializer(serializers.ModelSerializer):
+    area_nombre = serializers.CharField(source="area.nombre", read_only=True)
+    division_nombre = serializers.CharField(source="area.division.nombre", read_only=True)
+
+    class Meta:
+        model = Zona
+        fields = ("id", "area", "area_nombre", "division_nombre", "nombre")
+
+
 class VDFSerializer(serializers.ModelSerializer):
-    """
-    Serializa un VDF y adjunta su última lectura en el campo 'latest'.
-    Esto evita tener que hacer otra llamada para ver el valor más reciente.
-    """
+    """Serializa un VDF y adjunta su última lectura en el campo 'latest'."""
+
     latest = serializers.SerializerMethodField()    # Campo calculado por método
+    division = serializers.SerializerMethodField()
+    area = serializers.SerializerMethodField()
+    zone = serializers.SerializerMethodField()
+    zona = serializers.PrimaryKeyRelatedField(
+        queryset=Zona.objects.all(), allow_null=True, required=False
+    )
 
     class Meta:
         model = VDF
-        # Campos del VDF que exponemos en la API (incluye agrupaciones y descripción)
         fields = (
-            'id', 'nombre', 'division', 'area', 'zone',
-            'ip', 'slot', 'tag', 'tipo', 'descripcion',
-            'latest',                                   # última lectura adjunta
+            "id",
+            "nombre",
+            "division",
+            "area",
+            "zone",
+            "zona",
+            "ip",
+            "slot",
+            "tag",
+            "tipo",
+            "descripcion",
+            "latest",
         )
 
+    def get_division(self, obj):
+        if obj.zona_id:
+            return obj.zona.area.division.nombre
+        return obj.division
+
+    def get_area(self, obj):
+        if obj.zona_id:
+            return obj.zona.area.nombre
+        return obj.area
+
+    def get_zone(self, obj):
+        if obj.zona_id:
+            return obj.zona.nombre
+        return obj.zone
+
     def get_latest(self, obj):
-        """
-        Retorna la última lectura (por timestamp) del VDF.
-        Soporta dos escenarios:
-          1) Si el ForeignKey en Lectura usa related_name='lecturas', usamos obj.lecturas
-          2) Si NO tiene related_name, usamos el manager por defecto: obj.lectura_set
-        """
+        """Retorna la última lectura (por timestamp) del VDF."""
+
         # Intenta primero con 'lecturas' (caso limpio con related_name)
-        rel = getattr(obj, 'lecturas', None)         # None si no existe el atributo
+        rel = getattr(obj, "lecturas", None)
 
         # Si no hay 'lecturas', usa el manager inverso por defecto de Django
         if rel is None:
-            rel = obj.lectura_set                    # ← nombre por defecto (SIN “s” extra)
+            rel = obj.lectura_set
 
         # Obtiene la última lectura por fecha (descendente); puede ser None si no hay datos
-        ultimo = rel.order_by('-timestamp').first()
+        ultimo = rel.order_by("-timestamp").first()
 
         # Si hay lectura, la serializamos; si no, devolvemos None
         return LecturaSerializer(ultimo).data if ultimo else None

--- a/vdf_monitor/serializers.py
+++ b/vdf_monitor/serializers.py
@@ -36,9 +36,9 @@ class VDFSerializer(serializers.ModelSerializer):
     """Serializa un VDF y adjunta su última lectura en el campo 'latest'."""
 
     latest = serializers.SerializerMethodField()    # Campo calculado por método
-    division = serializers.SerializerMethodField()
-    area = serializers.SerializerMethodField()
-    zone = serializers.SerializerMethodField()
+    division_name = serializers.SerializerMethodField()
+    area_name = serializers.SerializerMethodField()
+    zona_name = serializers.SerializerMethodField()
     zona = serializers.PrimaryKeyRelatedField(
         queryset=Zona.objects.all(), allow_null=True, required=False
     )
@@ -48,9 +48,9 @@ class VDFSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "nombre",
-            "division",
-            "area",
-            "zone",
+            "division_name",
+            "area_name",
+            "zona_name",
             "zona",
             "ip",
             "slot",
@@ -60,17 +60,17 @@ class VDFSerializer(serializers.ModelSerializer):
             "latest",
         )
 
-    def get_division(self, obj):
+    def get_division_name(self, obj):
         if obj.zona_id:
             return obj.zona.area.division.nombre
         return obj.division
 
-    def get_area(self, obj):
+    def get_area_name(self, obj):
         if obj.zona_id:
             return obj.zona.area.nombre
         return obj.area
 
-    def get_zone(self, obj):
+    def get_zona_name(self, obj):
         if obj.zona_id:
             return obj.zona.nombre
         return obj.zone

--- a/vdf_monitor/views.py
+++ b/vdf_monitor/views.py
@@ -1,8 +1,14 @@
 # vdf_monitor/views.py
 from rest_framework import generics   # Vistas genéricas de DRF
-from django.db.models import Prefetch # Optimización opcional
-from .models import VDF, Lectura
-from .serializers import VDFSerializer, LecturaSerializer
+from django.db.models import Q  # Filtros avanzados
+from .models import Division, Area, Zona, VDF, Lectura
+from .serializers import (
+    DivisionSerializer,
+    AreaSerializer,
+    ZonaSerializer,
+    VDFSerializer,
+    LecturaSerializer,
+)
 
 class VDFListAPIView(generics.ListAPIView):
     """
@@ -27,11 +33,13 @@ class VDFListAPIView(generics.ListAPIView):
         if tipo:
             qs = qs.filter(tipo=tipo)
         if division:
-            qs = qs.filter(division=division)
+            qs = qs.filter(
+                Q(zona__area__division__nombre=division) | Q(division=division)
+            )
         if area:
-            qs = qs.filter(area=area)
+            qs = qs.filter(Q(zona__area__nombre=area) | Q(area=area))
         if zone:
-            qs = qs.filter(zone=zone)
+            qs = qs.filter(Q(zona__nombre=zone) | Q(zone=zone))
         if ip:
             qs = qs.filter(ip=ip)
         if tag:
@@ -48,6 +56,35 @@ class VDFListAPIView(generics.ListAPIView):
 
         # --- Optimización opcional: prefetch de lecturas si quisieras histórico ---
         # (No es estrictamente necesario para 'latest', que ya se resuelve en el serializer)
+        return qs
+
+
+class DivisionListCreateAPIView(generics.ListCreateAPIView):
+    queryset = Division.objects.all().order_by("nombre")
+    serializer_class = DivisionSerializer
+
+
+class AreaListCreateAPIView(generics.ListCreateAPIView):
+    serializer_class = AreaSerializer
+
+    def get_queryset(self):
+        qs = Area.objects.select_related("division").order_by("division__nombre", "nombre")
+        division_id = self.request.query_params.get("division_id")
+        if division_id:
+            qs = qs.filter(division_id=division_id)
+        return qs
+
+
+class ZonaListCreateAPIView(generics.ListCreateAPIView):
+    serializer_class = ZonaSerializer
+
+    def get_queryset(self):
+        qs = Zona.objects.select_related("area", "area__division").order_by(
+            "area__division__nombre", "area__nombre", "nombre"
+        )
+        area_id = self.request.query_params.get("area_id")
+        if area_id:
+            qs = qs.filter(area_id=area_id)
         return qs
 
 class LecturaListAPIView(generics.ListAPIView):

--- a/vdf_monitor/views.py
+++ b/vdf_monitor/views.py
@@ -51,8 +51,14 @@ class VDFListAPIView(generics.ListAPIView):
         if ordering in {'nombre', '-nombre', 'tipo', '-tipo', 'tag', '-tag', 'ip', '-ip'}:
             qs = qs.order_by(ordering)
         else:
-            # Orden por defecto (coherente: por división/área/zona y luego por tipo/tag)
-            qs = qs.order_by('division', 'area', 'zone', 'tipo', 'tag')
+            # Orden por defecto usando la jerarquía normalizada
+            qs = qs.order_by(
+                'zona__area__division__nombre',
+                'zona__area__nombre',
+                'zona__nombre',
+                'tipo',
+                'tag',
+            )
 
         # --- Optimización opcional: prefetch de lecturas si quisieras histórico ---
         # (No es estrictamente necesario para 'latest', que ya se resuelve en el serializer)

--- a/vdf_project/urls.py
+++ b/vdf_project/urls.py
@@ -4,11 +4,20 @@ from django.urls import path
 from django.views.generic import RedirectView
 from django.conf import settings
 from django.conf.urls.static import static
-from vdf_monitor.views import VDFListAPIView, LecturaListAPIView
+from vdf_monitor.views import (
+    VDFListAPIView,
+    LecturaListAPIView,
+    DivisionListCreateAPIView,
+    AreaListCreateAPIView,
+    ZonaListCreateAPIView,
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', RedirectView.as_view(url='/admin/', permanent=False)),
+    path('api/divisiones/', DivisionListCreateAPIView.as_view(), name='division-list'),
+    path('api/areas/', AreaListCreateAPIView.as_view(), name='area-list'),
+    path('api/zonas/', ZonaListCreateAPIView.as_view(), name='zona-list'),
     path('api/vdfs/', VDFListAPIView.as_view(), name='vdf-list'),
     path('api/lecturas/', LecturaListAPIView.as_view(), name='lectura-list'),
 ]


### PR DESCRIPTION
## Summary
- expose Division, Area, and Zona in the admin and REST API
- allow VDF serializer & listing to use normalized zone hierarchy
- add endpoints to list/create divisions, areas, and zones
- use zona relation in VDF admin form with autocomplete and hide legacy text fields

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689cc910be44832d8b8097f648614f39